### PR TITLE
Swap attribute mapping delimiter

### DIFF
--- a/lib/redmine_omniauth_saml.rb
+++ b/lib/redmine_omniauth_saml.rb
@@ -64,7 +64,7 @@ module Redmine::OmniAuthSAML
         HashWithIndifferentAccess.new.tap do |h|
           required_attribute_mapping.each do |symbol|
             key = configured_saml[:attribute_mapping][symbol]
-            h[symbol] = key.split('.')                # Get an array with nested keys: name.first will return [name, first]
+            h[symbol] = key.split('#')                # Get an array with nested keys: name.first will return [name, first]
               .map {|x| [:[], x]}                     # Create pair elements being :[] symbol and the key
               .inject(omniauth) do |hash, params|     # For each key, apply method :[] with key as parameter
                 hash.send(*params)

--- a/sample-saml-initializers.rb
+++ b/sample-saml-initializers.rb
@@ -13,10 +13,10 @@ Redmine::OmniAuthSAML::Base.configure do |config|
     :name_identifier_value          => "mail", # Which redmine field is used as name_identifier_value for SAML logout
     :attribute_mapping              => {
     # How will we map attributes from SSO to redmine attributes
-      :login      => 'extra.raw_info.username',
-      :mail       => 'extra.raw_info.email',
-      :firstname  => 'extra.raw_info.firstname',
-      :lastname   => 'extra.raw_info.firstname'
+      :login      => 'extra#raw_info#username',
+      :mail       => 'extra#raw_info#email',
+      :firstname  => 'extra#raw_info#firstname',
+      :lastname   => 'extra#raw_info#firstname'
     }
   }
 


### PR DESCRIPTION
SSO attributes may include schema URI (ex. "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress").  Using a period (.) to delimit the attributes fails in this case. Replace the delimiter with hash/pound (#) to prevent this error.